### PR TITLE
OC-381

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -64,8 +64,6 @@ class HomePage extends React.Component<Props, State> {
       await this.props.loadHomepage();
       await this.props.loadMore();
     }
-
-    $(window).on('load resize orientationchange', this.normalizeSlideHeights);
   }
 
   componentWillUnmount = () => {
@@ -81,7 +79,7 @@ class HomePage extends React.Component<Props, State> {
     }
 
     if (!isEqual(this.state.announcements, this.props.announcements)) {
-      this.setState({ announcements: this.props.announcements }, () => this.normalizeSlideHeights());
+      this.setState({ announcements: this.props.announcements });
     }
   }
 
@@ -135,21 +133,6 @@ class HomePage extends React.Component<Props, State> {
         window.removeEventListener('scroll', this.handleScrollMobileSearch, false);
       }
     }
-  }
-
-  normalizeSlideHeights = () => {
-    const _self = this;
-    $('.carousel').each(function() {
-      const items = $('.carousel-item', this);
-      // set the height
-      if (!_self.announcementsSlidesHeight) {
-        _self.announcementsSlidesHeight = Math.max.apply(null, items.map(function () {
-          return $(this).outerHeight();
-        }).get());
-      }
-
-      items.css('min-height', _self.announcementsSlidesHeight + 'px');
-    });
   }
 
   announcementsAmountToShow (): number {

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -64,10 +64,13 @@ class HomePage extends React.Component<Props, State> {
       await this.props.loadHomepage();
       await this.props.loadMore();
     }
+
+    $(window).on('load resize orientationchange', this.normalizeSlideHeights);
   }
 
   componentWillUnmount = () => {
     this._isMounted = false;
+    $(window).off('load resize orientationchange', this.normalizeSlideHeights);
     window.removeEventListener('scroll', this.scrollDebounce, false);
     window.removeEventListener('scroll', this.handleScrollMobileSearch, false);
   }
@@ -79,7 +82,7 @@ class HomePage extends React.Component<Props, State> {
     }
 
     if (!isEqual(this.state.announcements, this.props.announcements)) {
-      this.setState({ announcements: this.props.announcements });
+      this.setState({ announcements: this.props.announcements }, () => this.normalizeSlideHeights());
     }
   }
 
@@ -133,6 +136,21 @@ class HomePage extends React.Component<Props, State> {
         window.removeEventListener('scroll', this.handleScrollMobileSearch, false);
       }
     }
+  }
+
+  normalizeSlideHeights = () => {
+    const _self = this;
+    $('.carousel').each(function() {
+      const items = $('.carousel-item', this);
+      // set the height
+      if (!_self.announcementsSlidesHeight) {
+        _self.announcementsSlidesHeight = Math.max.apply(null, items.map(function () {
+          return $(this).outerHeight();
+        }).get());
+      }
+
+      items.css('min-height', _self.announcementsSlidesHeight + 'px');
+    });
   }
 
   announcementsAmountToShow (): number {

--- a/src/styles/components/pages/viewItem.scss
+++ b/src/styles/components/pages/viewItem.scss
@@ -102,37 +102,15 @@
 
   // NOTE this is the same height as .detailPreview picture image
   .carousel {
-    min-height: 350px;
-    @media screen and (min-width: 768px) {
-      min-height: 70vh;
-    }
-
-    // iPad Pro
-    @media only screen
-    and (min-device-width: 768px)
-    and (max-device-width: 1024px)
-    and (orientation: portrait)
-    and (-webkit-min-device-pixel-ratio: 2) {
-      min-height: 400px;
-    }
-    @media only screen and (min-width: 768px) and (max-width: 1091px), (min-height: 1500px) {
-      min-height: 400px;
-    }
-
     .carousel-indicators {
       margin-bottom: -1rem;
     }
-    .carousel-control-next {
+    .carousel-control-next, .carousel-control-prev {
+      cursor: pointer;
       width: 50px;
       height: 50px;
-      top: 45%;
-      right: 4%
-    }
-    .carousel-control-prev {
-      width: 50px;
-      height: 50px;
-      top: 45%;
-      left: 4%
+      top: 50%;
+      transform: translateY(-50%);
     }
   }
 }


### PR DESCRIPTION
In the case where content is higher in another slide you're going to get a slightish (dependent on content) jump for the offset.

See dev data collection http://localhost:3000/collection/4

Where as this collection - https://ocean-archive.org/collection/15 - all content was uniform (a fixed height though) which left a bit of empty space under the slides.

Just an FYI, the reason the slide controls are full height (Bootstrap4) is to allow sliding when clicking above or below the arrow, not straight on the arrow itself. BS4's carousel is ultimately used for a set of single items, not multiple dynamic in height.