### PR TITLE
[OC-443]: Align hamburger menu text to trailing

### DIFF
--- a/src/components/utils/SpecialMenu.tsx
+++ b/src/components/utils/SpecialMenu.tsx
@@ -42,7 +42,7 @@ export default class SpecialMenu extends Component<Props,{}> {
   collections_to_display_in = ['51','49','67','68', '69', '53'];
 
   toDisplay = (): boolean => {
-    if (window.location.pathname.match(/collection/) && this.collections_to_display_in.includes(this.props.id as string)) {
+    if (this.collections_to_display_in.includes(this.props.id as string)) {
       return true;
     } else if (this.props.id==='963') {
       return true
@@ -56,7 +56,7 @@ export default class SpecialMenu extends Component<Props,{}> {
     return (
       <div className="col-12 list" id="specialMenu">
         {window.location.pathname.match(/collection\/51/) ? 
-          (<div className="current" id="51">
+          (<div className="current" id={`specialmenu${this.props.id}`}>
              <CollectionIcon /> Sensing the Oceans: Anthropogenic Drivers</div>)
           :
 
@@ -69,7 +69,7 @@ export default class SpecialMenu extends Component<Props,{}> {
         }
         <hr />
         {this.mappings_ids_inOrder.map((id)=> 
-          id === window.location.pathname.split('/')[-1] ? <div className="current" id={id}>{this.mappings[id].title}</div> : 
+          id === window.location.pathname.split('/')[-1] ? <div className="current" id={`specialmenu${id}`}>{this.mappings[id].title}</div> : 
           <div className="related">
             <a className="collection_link" href={`/view/${id}`} target="_self" rel={id} id={id}>
             {this.mappings[id].title}</a>

--- a/src/components/utils/SpecialMenu.tsx
+++ b/src/components/utils/SpecialMenu.tsx
@@ -39,7 +39,7 @@ export default class SpecialMenu extends Component<Props,{}> {
     '896'
   ]
 
-  collections_to_display_in = ['51','49','67','68', '69', '53'];
+  collections_to_display_in = ['51','49','67','68', '69', '53', '73'];
 
   toDisplay = (): boolean => {
     if (this.collections_to_display_in.includes(this.props.id as string)) {

--- a/src/styles/base/bootstrap_overrides.scss
+++ b/src/styles/base/bootstrap_overrides.scss
@@ -1,3 +1,11 @@
 .min-h-100 {
   min-height: 100vh;
 }
+
+.navbar-toggler {
+  padding: 0
+}
+
+.navbar-brand {
+  padding: 0
+}

--- a/src/styles/layout/_navigation.scss
+++ b/src/styles/layout/_navigation.scss
@@ -16,16 +16,10 @@
 }
 
 .home svg{
-  position:absolute;
-  left: 15px;
-  top: 15px;
-  height: 25px;
-  width: 25px;
-
   g {
     fill: #7E7E7E;
   }
-  
+
 }
 .home:hover svg g{
     fill: #EEEEEE;
@@ -49,6 +43,10 @@
     }
     .nav-item {
       .nav-link {
+        @media screen and (max-width: 767px) {
+          width: 100%;
+          text-align: right;
+        }
         @media screen and (min-width: 768px) {
           padding-left: 1rem;
         }


### PR DESCRIPTION
**What's done:**
- Aligned hamburger menu text to trailing.
- Centered home and hamburger icons

![oc-443](https://user-images.githubusercontent.com/11477718/83124598-9760d900-a100-11ea-8a47-db36c070f271.gif)
