### PR TITLE
[OC-445]: Changed "Share" button from text to icon

### DIFF
--- a/src/components/collection/ViewCollection.tsx
+++ b/src/components/collection/ViewCollection.tsx
@@ -447,16 +447,17 @@ class ViewCollection extends React.Component<Props, State> {
                 {creators ? creators.join(', ') : <></>}
               </Col>
             </Row>
-
             <Row>
-              <div className="flex items-center">
-              <h1>{title}</h1>
-              {!!id &&
-                  <h3 style={{marginLeft: "0.5rem"}}>
-                    <Share suffix={`collection/${id}`} />
-                  </h3>
-                }
-              </div>
+              <Col>
+                <div className="flex items-center justify-between">
+                  <h1>{title}</h1>
+                  {!!id &&
+                    <h3 style={{ marginLeft: "1rem" }}>
+                      <Share suffix={`collection/${id}`} />
+                    </h3>
+                  }
+                </div>
+              </Col>
             </Row>
             <Row>
               <Col className="description">

--- a/src/components/collection/ViewCollection.tsx
+++ b/src/components/collection/ViewCollection.tsx
@@ -449,7 +449,7 @@ class ViewCollection extends React.Component<Props, State> {
             </Row>
 
             <Row>
-              <div style={{display: "flex", alignItems: "center"}}>
+              <div className="flex items-center">
               <h1>{title}</h1>
               {!!id &&
                   <h3 style={{marginLeft: "0.5rem"}}>

--- a/src/components/collection/ViewCollection.tsx
+++ b/src/components/collection/ViewCollection.tsx
@@ -420,8 +420,8 @@ class ViewCollection extends React.Component<Props, State> {
 
         <Row>
           {
-            this.state.firstItem ? 
-              (this.state.firstItem.item_type === 'IFrame' ? 
+            this.state.firstItem ?
+              (this.state.firstItem.item_type === 'IFrame' ?
                 (
 
                   <DataLayout
@@ -431,7 +431,7 @@ class ViewCollection extends React.Component<Props, State> {
                   collectionModalToggle={this.collectionModalToggle}
                   firstItem={true}
                   />
-                ) : 
+                ) :
                 (
                   <FilePreview file={this.state.firstItem.file} isHeader={true} />
                 )
@@ -449,9 +449,14 @@ class ViewCollection extends React.Component<Props, State> {
             </Row>
 
             <Row>
-              <Col>
-                <h1>{title}</h1>
-              </Col>
+              <div style={{display: "flex", alignItems: "center"}}>
+              <h1>{title}</h1>
+              {!!id &&
+                  <h3 style={{marginLeft: "0.5rem"}}>
+                    <Share suffix={`collection/${id}`} />
+                  </h3>
+                }
+              </div>
             </Row>
             <Row>
               <Col className="description">
@@ -462,17 +467,6 @@ class ViewCollection extends React.Component<Props, State> {
                 }
               </Col>
             </Row>
-
-            {!!id ?
-              (
-                <Row>
-                  <Col className="text-right">
-                    <Share suffix={`collection/${id}`}/>
-                  </Col>
-                </Row>
-              )
-              : <></>
-            }
 
             <Row id={this.state.dataRowID}>
             {

--- a/src/components/item/ViewItem.tsx
+++ b/src/components/item/ViewItem.tsx
@@ -219,14 +219,16 @@ class ViewItem extends React.Component<Props, State> {
               </Col>
             </Row>
             <Row>
-              <div style={{display: "flex", alignItems: "center"}}>
-              <h1>{title}</h1>
-              {!!id &&
-                  <h3 style={{marginLeft: "0.5rem"}}>
-                    <Share suffix={`collection/${id}`} />
-                  </h3>
-                }
-              </div>
+              <Col>
+                <div className="flex items-center justify-between">
+                  <h1>{title}</h1>
+                  {!!id &&
+                    <h3 style={{ marginLeft: "1rem" }}>
+                      <Share suffix={`collection/${id}`} />
+                    </h3>
+                  }
+                </div>
+              </Col>
             </Row>
 
             <Row>

--- a/src/components/item/ViewItem.tsx
+++ b/src/components/item/ViewItem.tsx
@@ -219,9 +219,14 @@ class ViewItem extends React.Component<Props, State> {
               </Col>
             </Row>
             <Row>
-              <Col>
-                <h1>{title}</h1>
-              </Col>
+              <div style={{display: "flex", alignItems: "center"}}>
+              <h1>{title}</h1>
+              {!!id &&
+                  <h3 style={{marginLeft: "0.5rem"}}>
+                    <Share suffix={`collection/${id}`} />
+                  </h3>
+                }
+              </div>
             </Row>
 
             <Row>
@@ -242,17 +247,6 @@ class ViewItem extends React.Component<Props, State> {
                 }
               </Col>
             </Row>
-
-            {!!id ?
-                (
-                    <Row>
-                      <Col className="text-right">
-                        <Share suffix={`view/${id}`}/>
-                      </Col>
-                    </Row>
-                )
-              : <></>
-            }
 
           </Col>
           <Col xs="12" md="4" className="right">

--- a/src/components/utils/Share.tsx
+++ b/src/components/utils/Share.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Clipboard from 'react-clipboard.js';
 
 import 'styles/utils/share.scss';
+import { FaExternalLinkAlt } from 'react-icons/fa';
 
 interface State {
   clicked: boolean;
@@ -62,7 +63,7 @@ export default class Share extends React.Component<Props, State> {
             {
               this.state.error ?
                 this.state.error :
-                this.state.clicked ? 'Copied!' : 'Share'
+                this.state.clicked ? 'Link Copied!' : <FaExternalLinkAlt />
             }
           </Clipboard>
         </div>

--- a/src/components/utils/Share.tsx
+++ b/src/components/utils/Share.tsx
@@ -63,7 +63,7 @@ export default class Share extends React.Component<Props, State> {
             {
               this.state.error ?
                 this.state.error :
-                this.state.clicked ? 'Link Copied!' : <FaExternalLinkAlt />
+                this.state.clicked ? 'Copied!' : <FaExternalLinkAlt />
             }
           </Clipboard>
         </div>

--- a/src/styles/layout/main.scss
+++ b/src/styles/layout/main.scss
@@ -21,3 +21,15 @@ h1, h2, h3, h4, h5, h6 {
 h1 {
   font-size: 40px;
 }
+
+.flex {
+  display: flex;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}

--- a/src/styles/utils/share.scss
+++ b/src/styles/utils/share.scss
@@ -3,7 +3,7 @@
 .share {
   button {
     cursor: pointer;
-    color: $mid-gray !important;
+    color: $mid-gray;
     background: none;
     border: none;
     &:focus {

--- a/src/styles/utils/share.scss
+++ b/src/styles/utils/share.scss
@@ -2,6 +2,7 @@
 
 .share {
   button {
+    text-align: right;
     cursor: pointer;
     color: $mid-gray;
     background: none;

--- a/src/styles/utils/share.scss
+++ b/src/styles/utils/share.scss
@@ -1,14 +1,10 @@
 @import "../base/variables";
 
 .share {
-  padding: 20px 0 20px 0;
-  @media screen and (min-width: 768px) {
-    padding: 40px 0 40px 0;
-  }
   button {
     cursor: pointer;
+    color: $mid-gray !important;
     background: none;
-    color: $subline-gray;
     border: none;
     &:focus {
       outline: none;


### PR DESCRIPTION
What's done: 
- Change share text button to icon
- Moved share icon from:
    -  bottom of description to 
    - side of title
- Introduced `flex` utility classes. I need this as `Reactstrap` don't have necessary API to align items on center
- On share click, changed "Copied" to "Link Copied". Introduced this for clarity as "Copied" is unclear as the text is now moved beside the title.