### PR TITLE
Add Redux Devtools for improved developer experience

### DIFF
--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -4,10 +4,12 @@ import rootReducer from '../reducers/';
 
 const middleware = [thunk];
 
+const composeEnhancers = (process.env.NODE_ENV === "development" && (window && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) )|| compose;
+
 const store: Store = createStore(
   rootReducer,
   {},
-  compose(
+  composeEnhancers(
     applyMiddleware(...middleware)
   )
 );


### PR DESCRIPTION
As title shows, this helps me debug redux store directly from browser. I've made sure it only show on "development" environment.

Example screenshot of devtools below.

<img width="1440" alt="Screen Shot 2020-06-02 at 17 42 37" src="https://user-images.githubusercontent.com/11477718/83511379-c27c6b80-a4f8-11ea-962a-89aaa21f8a19.png">
