### PR TITLE
[OC-447]: Fix video headers in collections only

### DIFF
--- a/src/components/collection/ViewCollection.tsx
+++ b/src/components/collection/ViewCollection.tsx
@@ -420,7 +420,7 @@ class ViewCollection extends React.Component<Props, State> {
                   />
                 ) :
                 (
-                  <FilePreview file={this.state.firstItem.file}/>
+                  <FilePreview file={this.state.firstItem.file} isHeader={true}/>
                 )
               )
                 : <></>

--- a/src/components/collection/ViewCollection.tsx
+++ b/src/components/collection/ViewCollection.tsx
@@ -405,8 +405,7 @@ class ViewCollection extends React.Component<Props, State> {
     return (
       <div id="item" className="container-fluid">
         <ErrorMessage message={this.props.errorMessage} />
-
-        <Row>
+        <Row className="file">
           {
             this.state.firstItem ?
               (this.state.firstItem.item_type === 'IFrame' ?
@@ -421,7 +420,7 @@ class ViewCollection extends React.Component<Props, State> {
                   />
                 ) :
                 (
-                  <FilePreview file={this.state.firstItem.file} isHeader={true} />
+                  <FilePreview file={this.state.firstItem.file}/>
                 )
               )
                 : <></>

--- a/src/components/utils/FilePreview.tsx
+++ b/src/components/utils/FilePreview.tsx
@@ -6,7 +6,12 @@ import { thumbnailsSRCSET } from './s3File';
 
 import textImage from 'images/defaults/Unscharfe_Zeitung.jpg';
 
-export const FilePreview = (props: { file: S3File }): JSX.Element => {
+let imageHeaderStyle = {
+  maxHeight: '35vh'
+}
+let emptyStyle = {}
+
+export const FilePreview = (props: { file: S3File, isHeader?: boolean }): JSX.Element => {
   switch (props.file.type) {
     case FileTypes.Image:
       // let background: string | undefined = undefined;
@@ -14,7 +19,7 @@ export const FilePreview = (props: { file: S3File }): JSX.Element => {
       //   background = props.file.thumbnails['1140'] || props.file.thumbnails['960'] || props.file.thumbnails['720'] || props.file.thumbnails['540'];
       // }
       return (
-        <Col className={'px-0 image text-center'}>
+        <Col className={props.isHeader ? "image" : "px-0 image text-center"} style={props.isHeader ? imageHeaderStyle : emptyStyle}>
           <img
             srcSet={thumbnailsSRCSET(props.file)}
             src={props.file.url}
@@ -53,7 +58,7 @@ export const FilePreview = (props: { file: S3File }): JSX.Element => {
 
     case FileTypes.DownloadText:
       return (
-        <Col className="px-0 image text-center">
+        <Col className="px-0 image">
           <a href={props.file.url} target="_blank" rel="noopener noreferrer">
             <img alt="" src={textImage} className="image-fluid"/>
           </a>

--- a/src/components/utils/FilePreview.tsx
+++ b/src/components/utils/FilePreview.tsx
@@ -58,7 +58,7 @@ export const FilePreview = (props: { file: S3File, isHeader?: boolean }): JSX.El
 
     case FileTypes.DownloadText:
       return (
-        <Col className="px-0 image">
+        <Col className="px-0 image text-center">
           <a href={props.file.url} target="_blank" rel="noopener noreferrer">
             <img alt="" src={textImage} className="image-fluid"/>
           </a>

--- a/src/components/utils/FilePreview.tsx
+++ b/src/components/utils/FilePreview.tsx
@@ -14,7 +14,7 @@ export const FilePreview = (props: { file: S3File }): JSX.Element => {
       //   background = props.file.thumbnails['1140'] || props.file.thumbnails['960'] || props.file.thumbnails['720'] || props.file.thumbnails['540'];
       // }
       return (
-        <Col className={'px-0 image text-center'} style={{maxHeight:"35vh"}}>
+        <Col className={'px-0 image text-center'}>
           <img
             srcSet={thumbnailsSRCSET(props.file)}
             src={props.file.url}

--- a/src/components/utils/FilePreview.tsx
+++ b/src/components/utils/FilePreview.tsx
@@ -6,7 +6,7 @@ import { thumbnailsSRCSET } from './s3File';
 
 import textImage from 'images/defaults/Unscharfe_Zeitung.jpg';
 
-export const FilePreview = (props: { file: S3File , isHeader?: boolean}): JSX.Element => {
+export const FilePreview = (props: { file: S3File }): JSX.Element => {
   switch (props.file.type) {
     case FileTypes.Image:
       // let background: string | undefined = undefined;
@@ -14,12 +14,11 @@ export const FilePreview = (props: { file: S3File , isHeader?: boolean}): JSX.El
       //   background = props.file.thumbnails['1140'] || props.file.thumbnails['960'] || props.file.thumbnails['720'] || props.file.thumbnails['540'];
       // }
       return (
-        <Col className={props.isHeader? 'px-0 image' : 'px-0 image text-center'} style={props.isHeader?{maxHeight:"35vh", left: "-5px"}:{}}>
+        <Col className={'px-0 image text-center'} style={{maxHeight:"35vh"}}>
           <img
             srcSet={thumbnailsSRCSET(props.file)}
             src={props.file.url}
             alt=""
-            style={props.isHeader? {width:"auto !important", height:"100%", paddingLeft: "2%"}:{}}
           />
           {/*<div className="background" style={{ background: `url(${!!background ? encodeURI(background) : props.file.url})`, backgroundSize: 'contain' }} />*/}
         </Col>
@@ -34,7 +33,6 @@ export const FilePreview = (props: { file: S3File , isHeader?: boolean}): JSX.El
             url={props.file.playlist || props.file.url}
             vertical-align="top"
             className="player"
-            style={props.isHeader? {paddingLeft: "2%"} : {}}
             config={{ file: { attributes: { poster: poster }} }}
           />
         </Col>


### PR DESCRIPTION
Issue happened because CSS className is missing
I also removed some unused CSS. Judging by the code, there's a difference in file preview between items and collections? Seems that we don't need it anymore now.

This fixes all file preview like image, video, etc
## Before: Video
<img width="1920" alt="Screen Shot 2020-06-04 at 20 28 02" src="https://user-images.githubusercontent.com/11477718/83766300-7111df00-a6a6-11ea-9f1c-bdb37623b8f2.png">

## After: Video
<img width="1919" alt="Screen Shot 2020-06-04 at 20 51 13" src="https://user-images.githubusercontent.com/11477718/83765435-5c811700-a6a5-11ea-8605-67aa1fa8cdee.png">

## Before: Image
<img width="1920" alt="Screen Shot 2020-06-04 at 20 59 34" src="https://user-images.githubusercontent.com/11477718/83766327-7b33dd80-a6a6-11ea-852e-3113a7398494.png">
## After: Image
<img width="1920" alt="Screen Shot 2020-06-04 at 20 59 42" src="https://user-images.githubusercontent.com/11477718/83766335-7d963780-a6a6-11ea-88bc-3a67a29af70f.png">

