### PR TITLE
Fix modal history bug

### DIFF
--- a/src/actions/home.tsx
+++ b/src/actions/home.tsx
@@ -2,11 +2,8 @@ import { API } from 'aws-amplify';
 import { HomepageData } from '../reducers/home';
 import { FileTypes } from '../types/s3File';
 import { itemType } from '../types/Item';
-import { COLLECTION_MODAL_TOGGLE } from './modals/collectionModal';
-import { ITEM_MODAL_TOGGLE } from './modals/itemModal';
 import { LIVESTREAM_MODAL_TOGGLE } from './modals/liveStreamModal';
 import * as React from 'react';
-import ReactGA from 'react-ga';
 import {
   DetailPreview,
   getItemsAndCollectionsForCollection
@@ -284,19 +281,9 @@ const waitForLoad = (loadedCount: number) => dispatch => {
 export const openModal = (data: HomepageData) => dispatch => {
   if (data.hasOwnProperty('count') || data.hasOwnProperty('items') || data.hasOwnProperty('type')) {
     // We have a collection.
-    ReactGA.modalview('/collection/'+data.id);
-    dispatch({
-     type: COLLECTION_MODAL_TOGGLE,
-     open: true,
-     data
-   });
+    dispatch(collectionModalToggle(true, data))
   } else {
-    ReactGA.modalview('/view/'+data.id);
-    dispatch({
-       type: ITEM_MODAL_TOGGLE,
-       open: true,
-       data
-     });
+    dispatch(itemModalToggle(true, data))
   }
 };
 

--- a/src/actions/modals/collectionModal.ts
+++ b/src/actions/modals/collectionModal.ts
@@ -2,6 +2,7 @@ import { HomepageData } from '../../reducers/home';
 import { Collection } from '../../types/Collection';
 import ReactGA from 'react-ga';
 import { clear as clearHistory } from 'actions/user-history';
+import { collectionURL } from '../../urls';
 
 // Defining our Actions for the reducers
 export const COLLECTION_MODAL_TOGGLE = 'COLLECTION_MODAL_TOGGLE';
@@ -9,7 +10,7 @@ export const COLLECTION_MODAL_TOGGLE = 'COLLECTION_MODAL_TOGGLE';
 // Modal
 export const toggle = (open: boolean, data?: HomepageData | Collection) => (dispatch, getState) => {
   if (open && data && data.id) {
-    ReactGA.modalview('/collection/'+data.id);
+    ReactGA.modalview(collectionURL(data.id));
   }
 
   const state = getState()

--- a/src/actions/modals/itemModal.ts
+++ b/src/actions/modals/itemModal.ts
@@ -1,11 +1,15 @@
 import { HomepageData } from '../../reducers/home';
 import { Item } from '../../types/Item';
 import { clear as clearHistory } from 'actions/user-history';
+import ReactGA from 'react-ga';
+import { itemURL } from 'urls';
 // Defining our Actions for the reducers
 export const ITEM_MODAL_TOGGLE = 'ITEM_MODAL_TOGGLE';
-
 // Modal
 export const toggle = (open: boolean, data?: HomepageData | Item) => (dispatch, getState) => {
+  if (open && data && data.id) {
+    ReactGA.modalview(itemURL(data.id));
+  }
   const state = getState()
   dispatch({
      type: ITEM_MODAL_TOGGLE,

--- a/src/components/item/ViewItems.tsx
+++ b/src/components/item/ViewItems.tsx
@@ -13,6 +13,7 @@ import { getCDNObject } from '../utils/s3File';
 import { FileTypes, S3File } from '../../types/s3File';
 
 import 'styles/components/ViewItems.scss';
+import { itemURL } from 'urls';
 
 interface Props extends Alerts {
   fetchItems: Function;
@@ -60,8 +61,7 @@ const MasonryItem = ( props: { item: Item } ): JSX.Element => {
       {item.file ? <FilePreview id={item.s3_key} file={item.file} /> : <></>}
       <CardBody>
         <Link
-          // to={`/view/${props.items.s3_key.split('/').slice(2).join('/')}`} // remove /private/UUID
-          to={`/view/${item.s3_key}`}
+          to={itemURL(item.s3_key)}
           className="item"
         >
           <CardTitle>{item.title}</CardTitle>

--- a/src/components/utils/SpecialMenu.tsx
+++ b/src/components/utils/SpecialMenu.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import 'styles/components/specialMenu.scss';
 
 import {ReactComponent as CollectionIcon} from '../../images/svgs/collection.svg';
+import { itemURL } from 'urls';
 
 interface Props {
   id?: string;
@@ -55,7 +56,7 @@ export default class SpecialMenu extends Component<Props,{}> {
     if (this.toDisplay()) {
     return (
       <div className="col-12 list" id="specialMenu">
-        {window.location.pathname.match(/collection\/51/) ? 
+        {window.location.pathname.match(/collection\/51/) ?
           (<div className="current" id={`specialmenu${this.props.id}`}>
              <CollectionIcon /> Sensing the Oceans: Anthropogenic Drivers</div>)
           :
@@ -64,20 +65,20 @@ export default class SpecialMenu extends Component<Props,{}> {
             <div className="related">
             <a className="collection_link" href={`/collection/51`} target="_self" rel="51" id="51">
             <CollectionIcon /> Sensing the Oceans: Anthropogenic Drivers</a>
-          </div> 
+          </div>
           )
         }
         <hr />
-        {this.mappings_ids_inOrder.map((id)=> 
-          id === window.location.pathname.split('/')[-1] ? <div className="current" id={`specialmenu${id}`}>{this.mappings[id].title}</div> : 
+        {this.mappings_ids_inOrder.map((id)=>
+          id === window.location.pathname.split('/')[-1] ? <div className="current" id={`specialmenu${id}`}>{this.mappings[id].title}</div> :
           <div className="related">
-            <a className="collection_link" href={`/view/${id}`} target="_self" rel={id} id={id}>
+            <a className="collection_link" href={itemURL(id)} target="_self" rel={id} id={id}>
             {this.mappings[id].title}</a>
-          </div> 
+          </div>
       )}
       </div>)
     } else {
       return (<></>)
     }
-  }   
+  }
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -55,7 +55,7 @@ import ItemModal from './components/modals/ItemModal';
 import CollectionModal from './components/modals/CollectionModal';
 import LiveStreamModal from './components/modals/LiveStreamModal';
 import About from './components/pages/About';
-import { viewProfileURL } from './urls';
+import { viewProfileURL, itemURL, collectionURL } from './urls';
 
 const LoggedInRoutes = ({ isAuthenticated, ...rest }) => {
   const isLoggedIn = isAuthenticated;
@@ -127,7 +127,7 @@ export const AppRouter = () => {
             <Switch>
               <Route exact path="/" component={Home} />
               <Route
-                path="/view/:id"
+                path={itemURL(':id')}
                 render={() => (
                   <div className="main pb blue">
                     <ViewItem />
@@ -143,7 +143,7 @@ export const AppRouter = () => {
                 )}
               />
               <Route
-                path="/collection/:id"
+                path={collectionURL(':id')}
                 render={() => (
                   <div className="main pb blue">
                     <ViewCollection />

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,2 +1,8 @@
 export const viewProfileURL = (id: string): string =>
   `/profiles/${id}`
+
+export const itemURL = (id: string): string =>
+  `/view/${id}`
+
+  export const collectionURL = (id: string): string =>
+  `/collection/${id}`


### PR DESCRIPTION
On staging, I noticed that modal history doesn't work properly. 

It happened because there's a manual instance that calls `modal toggle` directly instead through function. Fixed it here.

I also made `item/:id` and `collection/:id` works inside a function.